### PR TITLE
Fix: check the recorder state before call start()

### DIFF
--- a/src/hooks/conversation.ts
+++ b/src/hooks/conversation.ts
@@ -328,10 +328,11 @@ export const useConversation = (
     }
 
     if (recorderToUse.state === "recording") {
-      // the recorder is in the recording state, see:
+      // When the recorder is in the recording state, see:
       // https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/state
       // which is not expected to call `start()` according to:
       // https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start.
+      return;
     }
     recorderToUse.start(timeSlice);
   };

--- a/src/hooks/conversation.ts
+++ b/src/hooks/conversation.ts
@@ -327,6 +327,12 @@ export const useConversation = (
       timeSlice = 10;
     }
 
+    if (recorderToUse.state === "recording") {
+      // the recorder is in the recording state, see:
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/state
+      // which is not expected to call `start()` according to:
+      // https://developer.mozilla.org/en-US/docs/Web/API/MediaRecorder/start.
+    }
     recorderToUse.start(timeSlice);
   };
 


### PR DESCRIPTION
When two calls to start (returned by useCOnversation) are consecutive, it causes the following error:
```
Unhandled Runtime Error
InvalidStateError: Failed to execute 'start' on 'MediaRecorder': The MediaRecorder's state is 'recording'.

Call Stack
Object.start
node_modules/extendable-media-recorder/build/es2019/factories/webm-pcm-media-recorder.js (130:0)
MediaRecorder.start
node_modules/extendable-media-recorder/build/es2019/factories/media-recorder-constructor.js (149:0)
eval
node_modules/vocode/dist/hooks/conversation.js (269:0)
Generator.next
<anonymous>
fulfilled
node_modules/vocode/dist/hooks/conversation.js (5:42)
```
and the source code that compiles to

> node_modules/vocode/dist/hooks/conversation.js (269:0)
is:

`recorderToUse.start(timeSlice);`

This PR add a check before calling start() to prevent consecutive calls to start.