### PR TITLE
fix: turn off microphone recording when not active

### DIFF
--- a/src/hooks/conversation.ts
+++ b/src/hooks/conversation.ts
@@ -134,14 +134,15 @@ export const useConversation = (
     } else {
       setStatus("idle");
     }
-    if (!recorder || !socket || !audioStream) return;
-    recorder.stop();
-    audioStream.getTracks().forEach((track) => track.stop());
-    const stopMessage: StopMessage = {
-      type: "websocket_stop",
-    };
-    socket.send(stringify(stopMessage));
-    socket.close();
+    if (recorder) { recorder.stop() }
+    if (audioStream) { audioStream.getTracks().forEach((track) => track.stop()) }
+    if (socket) {
+      const stopMessage: StopMessage = {
+        type: "websocket_stop",
+      };
+      socket.send(stringify(stopMessage));
+      socket.close();
+    }
   };
 
   const getBackendUrl = async () => {


### PR DESCRIPTION
per https://stackoverflow.com/questions/44274410/mediarecorder-stop-doesnt-clear-the-recording-icon-in-the-tab - we should clean up the remaining streams in the stop function, in order to clear the recording icon. To do so, we need to persist audioStream outside of just the start function, and make it available to the stop function.

There are a couple other typing fixes here: `start` is an async function and should be annotated as such, also typing a couple variable declarations.

I've tested this on the demo app (modified for selfhosted backend) and can confirm that it properly turns off the recording icon.