### PR TITLE
Fixed broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Vocode React SDK
 
-See our [React Quickstart](https://docs.vocode.dev/react-quickstart) for set up!
+See our [React Quickstart](https://docs.vocode.dev/open-source/react-quickstart) for set up!


### PR DESCRIPTION
Previous link did not point to the proper documenation page. Updated link takes the user to the intended documentation